### PR TITLE
Build optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ dist: trusty
 services:
   - docker
 
-language: go
-
-go:
-  - "1.11"
+language: minimal
 
 # Only clone the most recent commit
 git:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.11.0-alpine3.8
+# ===> Build Image
+FROM golang:1.11.0-alpine3.8 AS builder
 LABEL maintainer="Jaskaranbir Dhillon"
 
 ARG SOURCE_REPO
@@ -20,4 +21,10 @@ RUN dep ensure --vendor-only -v
 COPY . ./
 
 RUN go build -v -a -installsuffix nocgo -o /app ./main
-ENTRYPOINT ["/app"]
+
+# ===> Run Image
+FROM scratch
+LABEL maintainer="Jaskaranbir Dhillon"
+
+COPY --from=builder /app ./
+ENTRYPOINT ["./app"]


### PR DESCRIPTION
* Use MultiStage Docker-build to push the final image to a minimal `scratch` image.
* Use `language: minimal` in Travis. This significantly speeds up the CI-builds.