### PR TITLE
Travis: Install deps if its tagged-commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ language: go
 go:
   - "1.11"
 
-# Don't go-get dependencies, since we are running everything
-# in docker-containers for testing.
-install: true
-
 # Only clone the most recent commit
 git:
   depth: 1
@@ -22,9 +18,19 @@ branches:
 
 env:
   global:
+    - DEP_VERSION="0.5.0"
     - DOCKER_COMPOSE_VERSION=1.22.0
 
+addons:
+  apt:
+    packages:
+      - docker-ce
+
 before_install:
+  # Download dep binary to $GOPATH/bin
+  - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
+  - chmod +x $GOPATH/bin/dep
+
   # Docker-Compose
   - sudo rm /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname
@@ -32,10 +38,9 @@ before_install:
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
 
-addons:
-  apt:
-    packages:
-      - docker-ce
+install:
+  # Only install local deps if its a tagged-commit
+  - if [[ ! -z ${TRAVIS_TAG} ]]; then dep ensure; fi
 
 before_script:
   - chmod +x ./run_test.sh

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This service handles persisting/storing the system-generated events into Cassand
 
 * This event is then processed, which includes Marshalling it into [Event][0] model and inserting it into Cassandra Event-Store.
 
-* The post-processing result is published to a Kafka Topic (`event.rns_eventstore.events.persistence.response`), which is based on [Kafka-Response][1] model. The event-producer must consume this result (by listening on the respective Kafka-Topic), check for errors, and proceed accordingly.
+* The post-processing result is published to a Kafka Topic (`event.rns_eventstore.events.persistence.response.<aggregate-id>`), which is based on [Kafka-Response][1] model. The event-producer must consume this result (by listening on the respective Kafka-Topic), check for errors, and proceed accordingly.
 
 Check [.env][2] and [docker-compose.yaml][3] (docker-compose is only used in tests as of yet) files for default configurations (including the Cassandra Keyspace/Table used).
 


### PR DESCRIPTION
Not installing deps fails when its a release. So we only install deps if its a tagged-commit.

Also fixes docs about kafka-response.