### PR TITLE
Set initial Meta-Version to 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .history
 .vagrant
 .vscode
-debug.test
+debug*
 vendor*

--- a/main/db.go
+++ b/main/db.go
@@ -6,6 +6,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+// EventStore represents the core functions required
+// to interact with EventStore for persisting events.
 type EventStore interface {
 	GetAggVersion(aggregateID int8) (int64, error)
 	CommitEvent(event *model.Event) error
@@ -17,6 +19,7 @@ type eventStore struct {
 	metaPartitionKey int8
 }
 
+// NewEventStore creates a new EventStore implementation from provided configuration.
 func NewEventStore(
 	eventTable *csndra.Table,
 	eventMetaTable *csndra.Table,
@@ -76,7 +79,7 @@ func (es *eventStore) GetAggVersion(aggregateID int8) (int64, error) {
 	}
 	if len(resultsBind) == 0 {
 		meta := model.EventMeta{
-			AggregateVersion: 1,
+			AggregateVersion: 2,
 			AggregateID:      aggregateID,
 			PartitionKey:     es.metaPartitionKey,
 		}


### PR DESCRIPTION
The initial aggregate-version is also 1, which causes no events to be captured since both meta-version and aggregate-version are 1.