### PR TITLE
Fix Dockerfile_ci using incorrect repo-name

### DIFF
--- a/Dockerfile_ci
+++ b/Dockerfile_ci
@@ -2,5 +2,5 @@
 FROM scratch
 LABEL maintainer="Jaskaranbir Dhillon"
 
-COPY /agg-metrics-cmd ./
+COPY /go-eventpersistence ./
 ENTRYPOINT ["./go-eventpersistence"]


### PR DESCRIPTION
bors r+